### PR TITLE
Add custom checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ checkbox that preserves the accessibility of a native checkbox (keyboard toggle)
 little JS as possible/reasonable.
 
 ## Acceptance Criteria
-- [x] The custom checkbox is styled similar to what you see in the video (find a
+- [x] The custom checkbox is styled similar to what you see in the [video](https://drive.google.com/file/d/1shYzkzHruC7gRQm1ixXVfd7u7OT07fnM/view?usp=sharing) (find a
 checkmark SVG in Assets below).
 - [x] Clicking the native checkbox, the custom checkbox is displayed and checked as
 well.
@@ -18,6 +18,22 @@ around the custom checkbox.
 space, the native checkbox is selected as well as the custom checkbox.
 - [x] When hiding the native checkbox, the native accessibility (keyboard navigation:
 tab, space) is preserved for the custom checkbox.
+
+## Assets
+Checkmark SVG
+```md
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+    <rect width="256" height="256" fill="none"></rect>
+    <polyline
+        points="216 72.005 104 184 48 128.005"
+        fill="none"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="16">
+    </polyline>
+</svg>
+```
 
 ## Executing code
 Open `index.html` file in your browser.

--- a/index.html
+++ b/index.html
@@ -8,5 +8,25 @@
 </head>
 <body>
     <h1>Custom Checkbox Challenge</h1>
+    <div class="container">
+        <label for="toggle">
+            <input type="checkbox" id="toggle" class="original-input">
+            <div class="custom-checkbox-focus">
+                <div class="custom-checkbox">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256">
+                        <rect width="256" height="256" fill="none"></rect>
+                        <polyline
+                            points="216 72.005 104 184 48 128.005"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="16">
+                        </polyline>
+                    </svg>
+                </div>
+            </div>
+        </label>
+    </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Custom Checkbox Challenge</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <h1>Custom Checkbox Challenge</h1>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -7,6 +7,19 @@ h1 {
     display: flex;
 }
 
+.original-input {
+    position: absolute;
+    height: 0;
+    width: 0;
+    margin: 0;
+    padding: 0;
+}
+
+/* Solves visibility of the original input for Safari browser */
+.original-input::-webkit-contacts-auto-fill-button {
+    opacity: 0;
+}
+
 .custom-checkbox-focus {
     position: relative;
 

--- a/styles.css
+++ b/styles.css
@@ -2,3 +2,47 @@ h1 {
     font-family: monospace;
     color: darkcyan;
 }
+
+.container {
+    display: flex;
+}
+
+.custom-checkbox-focus {
+    position: relative;
+
+    border: 0.2rem solid transparent;
+    border-radius: 0.6em;
+
+    display: grid;
+    place-items: center;
+    width: fit-content;
+}
+
+.custom-checkbox {
+    border: .15em solid black;
+    border-radius: 0.3em;
+
+    width: 2rem;
+    height: 2rem;
+
+    margin: 0.3em;
+
+    cursor: pointer;
+}
+
+.custom-checkbox-focus .custom-checkbox svg {
+    display: none;
+}
+
+.original-input:focus-visible ~ .custom-checkbox-focus {
+    border: 0.2rem solid blue;
+}
+
+.original-input:checked ~ .custom-checkbox-focus .custom-checkbox {
+    background-color: black;
+}
+
+.original-input:checked ~ .custom-checkbox-focus .custom-checkbox svg {
+    display: block;
+    color: white;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,4 @@
+h1 {
+    font-family: monospace;
+    color: darkcyan;
+}


### PR DESCRIPTION
Created a styled checkbox that preserves the accessibility of a native checkbox (keyboard toggle) using no JavaScript.

## The following acceptance criteria are fullfilled
- [x] The custom checkbox is styled similar to what you see in the [video](https://drive.google.com/file/d/1shYzkzHruC7gRQm1ixXVfd7u7OT07fnM/view?usp=sharing) (find a
checkmark SVG in Assets below).
- [x] Clicking the native checkbox, the custom checkbox is displayed and checked as
well.
- [x] Clicking the custom checkbox, the native checkbox is checked as well.
- [x] Using the keyboard (tab), when the native checkbox is focused, a blue line appears
around the custom checkbox.
- [x] Using the keyboard (tab), when the native checkbox has focus and the user presses
space, the native checkbox is selected as well as the custom checkbox.
- [x] When hiding the native checkbox, the native accessibility (keyboard navigation:
tab, space) is preserved for the custom checkbox.